### PR TITLE
Newer libmemcached doesn't like keys with no length.

### DIFF
--- a/lib/CHI/Driver/Memcached/t/CHIDriverTests/Base.pm
+++ b/lib/CHI/Driver/Memcached/t/CHIDriverTests/Base.pm
@@ -68,6 +68,17 @@ sub set_standard_keys_and_values {
     return ( $keys, $values );
 }
 
+sub extra_test_keys {
+    my ($self) = @_;
+
+    # Newer libmemcached does not like 0-length keys...
+    my @keys = grep {
+        length $_
+    } $self->SUPER::extra_test_keys;
+
+    return @keys;
+}
+
 # TODO - Not working right now - fix later
 sub test_size_awareness_with_subcaches { }
 sub test_max_size_with_l1_cache        { }


### PR DESCRIPTION
Previous versions of libmemcached would prepend the namespace to
a zero length key before submitting it to memcached.

Now it just returns an error, so don't attempt to call get_multi()
with such keys.
